### PR TITLE
(wallet address) : (ID Tag) = 1 : N 

### DIFF
--- a/contracts/OoakMinting.sol
+++ b/contracts/OoakMinting.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.5.0;
 
+
 import "./ownership/Ownable.sol";
 
 import "./token/KIP17/KIP17Token.sol";
@@ -36,7 +37,7 @@ contract OoakMinting is Ownable {
     }
 
     function registerNameTag(string memory twitchId, address publicKey, string memory nameTag) onlyOwner public {
-        require(bytes(getNameTag(twitchId)).length == 0, "already register nameTag");
+        //require(bytes(getNameTag(twitchId)).length == 0, "already register nameTag");
         require(!isNameTagExist[nameTag], "this nameTag already exist");
         require(lastTokenId < firstPreSaleLimit, "The first presale is sold out");
 
@@ -49,17 +50,24 @@ contract OoakMinting is Ownable {
         isNameTagExist[nameTag] = true;
     }
 
-    // function getNameTag(string memory twitchId) public view returns (string memory) {
-    //     uint256 _tokenId = getTokenId(twitchId);
-    //     return getNameTagWithTokenId(_tokenId);
+    //solidity 0.8.0 버전 이하에는 ABIEncoder V2가 적용되지 않아서 string array를 사용할 수 없음
+    //pragma experimental ABIEncoderV2; 를 적용하면 될 수 있지만, 보안상 취약할 수 있음
+    // function getNameTags(string memory twitchId) public view returns (string[] memory) {
+    //     uint256[] memory _tokenIds = getTokenIds(twitchId);
+    //     string[] memory _nameTags;
+    //     for (uint i=0; i<_tokenIds.length; i++) _nameTags[i] = getNameTagWithTokenId(_tokenIds[i]);
+    //     return _nameTags;
     // }
-    function getNameTags(string memory twitchId) public view returns (string[] memory) {
-        uint256[] _tokenIds = getTokenIds(twitchId);
-        string[] _nameTags;
-        for (uint i=0; i<_tokenIds.length; i++) _nameTags.push(getNameTagWithTokenId(_tokenIds[i]));
-        
-        return _nameTags;
+    function getNameTagByIndex(string memory twitchId, uint256 index) public view returns (string memory) {
+        uint256[] memory _tokenIds = getTokenIds(twitchId);
+        return getNameTagWithTokenId(_tokenIds[index]);
     }
+    //Name Tag 개수 가져오기
+    function getNameTagNumber(string memory twitchId) public view returns (uint256) { 
+        uint256[] memory _tokenIds = getTokenIds(twitchId);
+        return _tokenIds.length;
+    }
+
 
     function getNameTagWithTokenId(uint256 tokenId) public view returns (string memory) {
         return TokenIdToNameTag[tokenId];
@@ -69,45 +77,42 @@ contract OoakMinting is Ownable {
         return IdToAddress[twitchId];
     }
 
-    // function getTokenURI(string memory twitchId) public view returns (string memory) {
+    //solidity 0.8.0 버전 이하에는 ABIEncoder V2가 적용되지 않아서 string array를 사용할 수 없음
+    //pragma experimental ABIEncoderV2; 를 적용하면 될 수 있지만, 보안상 취약할 수 있음
+    // function getTokenURIs(string memory twitchId) public view returns (string[] memory) {
     //     require(IdToAddress[twitchId] != address(0), "address do not exist");
     //     address _address = IdToAddress[twitchId];
-    //     uint256 _tokenId = AddressToTokenId[_address];
-    //     return TokenIdToTokenURI[_tokenId];
+    //     uint256[] memory _tokenIds = AddressToTokenIds[_address];
+    //     string[] memory _tokenURIs;
+    //     for (uint i=0; i<_tokenIds.length; i++) _tokenURIs[i] = TokenIdToTokenURI[_tokenIds[i]];
+    //     return _tokenURIs;
     // }
-    function getTokenURIs(string memory twitchId) public view returns (string[] memory) {
+    function getTokenByIndex(string memory twitchId, uint256 index) public view returns (uint256) {
         require(IdToAddress[twitchId] != address(0), "address do not exist");
         address _address = IdToAddress[twitchId];
-        uint256[] _tokenIds = AddressToTokenIds[_address];
-        string[] _tokenURIs;
-        for (uint i=0; i<_tokenIds.length; i++) _tokenURIs.push(TokenIdToTokenURI[_tokenId[i]]);
-        return _tokenURIs;
+        return AddressToTokenIds[_address][index];
+    }
+    //Token 개수 가져오기
+    function getTokenNumber(string memory twitchId) public view returns (uint256) { 
+        require(IdToAddress[twitchId] != address(0), "address do not exist");
+        address _address = IdToAddress[twitchId];
+        return AddressToTokenIds[_address].length;
     }
 
-    // function getTokenId(string memory twitchId) public view returns (uint256) {
-    //     address _address = IdToAddress[twitchId];
-    //     return AddressToTokenId[_address];
-    // }
-    function getTokenIds(string memory twitchId) public view returns (uint256[]) {
+
+    function getTokenIds(string memory twitchId) public view returns (uint256[] memory) {
         address _address = IdToAddress[twitchId];
         return AddressToTokenIds[_address];
     }
     
-    // function mintNFTWithTokenURI(string memory twitchId, string memory tokenURI) onlyOwner public {
-    //     require(IdToAddress[twitchId] != address(0), "address do not exist");
-    //     address publicKey = IdToAddress[twitchId];
-    //     uint256 tokenId = AddressToTokenId[publicKey];
-    //     KIP17Token(NftContract).mintWithTokenURI(publicKey, tokenId, tokenURI);
-    //     TokenIdToTokenURI[tokenId] = tokenURI;
-    // }
 
     // TODO 확인 필요
     function mintNFTWithTokenURI(string memory twitchId, string memory tokenURI) onlyOwner public {
         require(IdToAddress[twitchId] != address(0), "address do not exist");
         address publicKey = IdToAddress[twitchId];
-        uint256[] tokenIds = AddressToTokenIds[publicKey];
+        uint256[] memory tokenIds = AddressToTokenIds[publicKey];
         KIP17Token(NftContract).mintWithTokenURI(publicKey, tokenIds[tokenIds.length-1], tokenURI); //tokenIds 중 마지막 tokenId 이용
-        TokenIdToTokenURI[tokenId] = tokenURI;
+        TokenIdToTokenURI[tokenIds.length-1] = tokenURI;
     }
 
 
@@ -116,32 +121,26 @@ contract OoakMinting is Ownable {
     }
     
     
-    // function changeOwnerOfNameTag(address srcAddress, address dstAddress, uint256 tokenId) public {
-    //     require(msg.sender == NftContract);
-    //     delete AddressToTokenId[srcAddress];
-    //     AddressToTokenId[dstAddress] = tokenId;
-    // }
     function changeOwnerOfNameTag(address srcAddress, address dstAddress, uint256 tokenId) public {
         require(msg.sender == NftContract);
         
         //tokenId가 있는 자리 delete
         uint deletedPlace = 0;
-        for(uint i=0; i<AddressToTokenId[srcAddress].length; i++){
-            if(AddressToTokenId[srcAddress][i] == tokenId){
-                delete AddressToTokenId[srcAddress][i];
+        for(uint i=0; i<AddressToTokenIds[srcAddress].length; i++){
+            if(AddressToTokenIds[srcAddress][i] == tokenId){
+                delete AddressToTokenIds[srcAddress][i];
                 deletedPlace = i;
                 break;
             }
         }
         //delete 한 자리 뒤 쪽 앞으로 당기기
-        for(uint i=deletedPlace; i<AddressToTokenId[srcAddress].length-1; i++){
+        for(uint i=deletedPlace; i<AddressToTokenIds[srcAddress].length-1; i++){
             
-            AddressToTokenId[srcAddress][i] = AddressToTokenId[srcAddress][i+1];
+            AddressToTokenIds[srcAddress][i] = AddressToTokenIds[srcAddress][i+1];
         }
-        AddressToTokenId[srcAddress].pop;
+        AddressToTokenIds[srcAddress].pop;
 
         //dstAddress 뒤에 tokenId 추가
         AddressToTokenIds[dstAddress][AddressToTokenIds[dstAddress].length] = tokenId;
     }
 }
-

--- a/contracts/OoakMinting.sol
+++ b/contracts/OoakMinting.sol
@@ -7,10 +7,17 @@ import "./ownership/Ownable.sol";
 import "./token/KIP17/KIP17Token.sol";
 
 contract OoakMinting is Ownable {
+
+
     // twitch ID to public address
     mapping(string => address) IdToAddress;
+
+
     // TODO : 여러 개의 NFT를 가지도록
-    mapping(address => uint256) AddressToTokenId;
+    //mapping(address => uint256) AddressToTokenId;
+    mapping(address => uint256[]) AddressToTokenIds;
+
+
     // NFT TokenId to NameTag
     mapping(uint256 => string) TokenIdToNameTag;
     // twitch ID(streamer) to public address
@@ -36,14 +43,22 @@ contract OoakMinting is Ownable {
         lastTokenId++;
 
         IdToAddress[twitchId] = publicKey;
-        AddressToTokenId[publicKey] = lastTokenId;
+        //AddressToTokenId[publicKey] = lastTokenId;
+        AddressToTokenIds[publicKey].push(lastTokenId);
         TokenIdToNameTag[lastTokenId] = nameTag;
         isNameTagExist[nameTag] = true;
     }
 
-    function getNameTag(string memory twitchId) public view returns (string memory) {
-        uint256 _tokenId = getTokenId(twitchId);
-        return getNameTagWithTokenId(_tokenId);
+    // function getNameTag(string memory twitchId) public view returns (string memory) {
+    //     uint256 _tokenId = getTokenId(twitchId);
+    //     return getNameTagWithTokenId(_tokenId);
+    // }
+    function getNameTags(string memory twitchId) public view returns (string[] memory) {
+        uint256[] _tokenIds = getTokenIds(twitchId);
+        string[] _nameTags;
+        for (uint i=0; i<_tokenIds.length; i++) _nameTags.push(getNameTagWithTokenId(_tokenIds[i]));
+        
+        return _nameTags;
     }
 
     function getNameTagWithTokenId(uint256 tokenId) public view returns (string memory) {
@@ -54,34 +69,79 @@ contract OoakMinting is Ownable {
         return IdToAddress[twitchId];
     }
 
-    function getTokenURI(string memory twitchId) public view returns (string memory) {
+    // function getTokenURI(string memory twitchId) public view returns (string memory) {
+    //     require(IdToAddress[twitchId] != address(0), "address do not exist");
+    //     address _address = IdToAddress[twitchId];
+    //     uint256 _tokenId = AddressToTokenId[_address];
+    //     return TokenIdToTokenURI[_tokenId];
+    // }
+    function getTokenURIs(string memory twitchId) public view returns (string[] memory) {
         require(IdToAddress[twitchId] != address(0), "address do not exist");
         address _address = IdToAddress[twitchId];
-        uint256 _tokenId = AddressToTokenId[_address];
-        return TokenIdToTokenURI[_tokenId];
+        uint256[] _tokenIds = AddressToTokenIds[_address];
+        string[] _tokenURIs;
+        for (uint i=0; i<_tokenIds.length; i++) _tokenURIs.push(TokenIdToTokenURI[_tokenId[i]]);
+        return _tokenURIs;
     }
 
-    function getTokenId(string memory twitchId) public view returns (uint256) {
+    // function getTokenId(string memory twitchId) public view returns (uint256) {
+    //     address _address = IdToAddress[twitchId];
+    //     return AddressToTokenId[_address];
+    // }
+    function getTokenIds(string memory twitchId) public view returns (uint256[]) {
         address _address = IdToAddress[twitchId];
-        return AddressToTokenId[_address];
+        return AddressToTokenIds[_address];
     }
     
+    // function mintNFTWithTokenURI(string memory twitchId, string memory tokenURI) onlyOwner public {
+    //     require(IdToAddress[twitchId] != address(0), "address do not exist");
+    //     address publicKey = IdToAddress[twitchId];
+    //     uint256 tokenId = AddressToTokenId[publicKey];
+    //     KIP17Token(NftContract).mintWithTokenURI(publicKey, tokenId, tokenURI);
+    //     TokenIdToTokenURI[tokenId] = tokenURI;
+    // }
+
+    // TODO 확인 필요
     function mintNFTWithTokenURI(string memory twitchId, string memory tokenURI) onlyOwner public {
         require(IdToAddress[twitchId] != address(0), "address do not exist");
         address publicKey = IdToAddress[twitchId];
-        uint256 tokenId = AddressToTokenId[publicKey];
-        KIP17Token(NftContract).mintWithTokenURI(publicKey, tokenId, tokenURI);
+        uint256[] tokenIds = AddressToTokenIds[publicKey];
+        KIP17Token(NftContract).mintWithTokenURI(publicKey, tokenIds[tokenIds.length-1], tokenURI); //tokenIds 중 마지막 tokenId 이용
         TokenIdToTokenURI[tokenId] = tokenURI;
     }
+
 
     function setNFTContract(address nftContract) onlyOwner public {
         NftContract = nftContract;
     }
-
+    
+    
+    // function changeOwnerOfNameTag(address srcAddress, address dstAddress, uint256 tokenId) public {
+    //     require(msg.sender == NftContract);
+    //     delete AddressToTokenId[srcAddress];
+    //     AddressToTokenId[dstAddress] = tokenId;
+    // }
     function changeOwnerOfNameTag(address srcAddress, address dstAddress, uint256 tokenId) public {
         require(msg.sender == NftContract);
-        delete AddressToTokenId[srcAddress];
-        AddressToTokenId[dstAddress] = tokenId;
+        
+        //tokenId가 있는 자리 delete
+        uint deletedPlace = 0;
+        for(uint i=0; i<AddressToTokenId[srcAddress].length; i++){
+            if(AddressToTokenId[srcAddress][i] == tokenId){
+                delete AddressToTokenId[srcAddress][i];
+                deletedPlace = i;
+                break;
+            }
+        }
+        //delete 한 자리 뒤 쪽 앞으로 당기기
+        for(uint i=deletedPlace; i<AddressToTokenId[srcAddress].length-1; i++){
+            
+            AddressToTokenId[srcAddress][i] = AddressToTokenId[srcAddress][i+1];
+        }
+        AddressToTokenId[srcAddress].pop;
+
+        //dstAddress 뒤에 tokenId 추가
+        AddressToTokenIds[dstAddress][AddressToTokenIds[dstAddress].length] = tokenId;
     }
 }
 

--- a/contracts/OoakMinting.sol
+++ b/contracts/OoakMinting.sol
@@ -87,10 +87,11 @@ contract OoakMinting is Ownable {
     //     for (uint i=0; i<_tokenIds.length; i++) _tokenURIs[i] = TokenIdToTokenURI[_tokenIds[i]];
     //     return _tokenURIs;
     // }
-    function getTokenByIndex(string memory twitchId, uint256 index) public view returns (uint256) {
+    function getTokenURIByIndex(string memory twitchId, uint256 index) public view returns (string memory) {
         require(IdToAddress[twitchId] != address(0), "address do not exist");
         address _address = IdToAddress[twitchId];
-        return AddressToTokenIds[_address][index];
+        uint256 _tokenId = AddressToTokenIds[_address][index];
+        return TokenIdToTokenURI[_tokenId];
     }
     //Token 개수 가져오기
     function getTokenNumber(string memory twitchId) public view returns (uint256) { 


### PR DESCRIPTION
지갑 주소와, ID Tag 를 일대다로 연결할 수 있게 만들었습니다.

solidity 0.8.0 버전 이하에는 ABIEncoder V2가 적용되지 않아서 string array를 사용할 수 없고,
pragma experimental ABIEncoderV2 를 적용하면 사용이 가능하지만, 보안 상 취약할 수 있다고 합니다.

그래서 string array로 값을 반환해야되는 getNameTags나 getTokenURIs 를 각각
getNameTagByIndex, getNameTagNumber 와 getTokenURIByIndex, getTokenNumber
두 개의 함수로 나눴습니다.

아직 테스트는 진행해보지 않은 상태입니다.